### PR TITLE
fix: skip archived posts in prev/next navigation

### DIFF
--- a/_includes/post-nav.html
+++ b/_includes/post-nav.html
@@ -1,12 +1,31 @@
 <!--
   Navigation buttons at the bottom of the post.
+  Skips posts flagged `archive: true` so archived posts do not leak back in via
+  prev/next — they are already hidden from the Archives listing. Walks to the
+  nearest non-archived neighbor in each direction; collapses to the disabled
+  state at a sequence boundary. See issue #4.
 -->
 
+{%- comment -%} Nearest non-archived neighbors by date. previous = older, next = newer. {%- endcomment -%}
+{% assign cur_ts = page.date | date: '%s' | plus: 0 %}
+{% assign prev_post = nil %}
+{% assign next_post = nil %}
+{% for p in site.posts %}
+  {% if p.archive == true %}{% continue %}{% endif %}
+  {% if p.url == page.url %}{% continue %}{% endif %}
+  {% assign p_ts = p.date | date: '%s' | plus: 0 %}
+  {% if p_ts < cur_ts %}
+    {% unless prev_post %}{% assign prev_post = p %}{% endunless %}
+  {% elsif p_ts > cur_ts %}
+    {% assign next_post = p %}
+  {% endif %}
+{% endfor %}
+
 <div class="post-navigation d-flex justify-content-between">
-  {% if page.previous.url %}
-  <a href="{{ site.baseurl }}{{ page.previous.url }}" class="btn btn-outline-primary"
+  {% if prev_post %}
+  <a href="{{ site.baseurl }}{{ prev_post.url }}" class="btn btn-outline-primary"
     prompt="{{ site.data.locales[lang].post.button.previous }}">
-    <p>{{ page.previous.title }}</p>
+    <p>{{ prev_post.title }}</p>
   </a>
   {% else %}
   <span class="btn btn-outline-primary disabled"
@@ -15,10 +34,10 @@
   </span>
   {% endif %}
 
-  {% if page.next.url %}
-  <a href="{{ site.baseurl }}{{page.next.url}}" class="btn btn-outline-primary"
+  {% if next_post %}
+  <a href="{{ site.baseurl }}{{ next_post.url }}" class="btn btn-outline-primary"
     prompt="{{ site.data.locales[lang].post.button.next }}">
-    <p>{{ page.next.title }}</p>
+    <p>{{ next_post.title }}</p>
   </a>
   {% else %}
   <span class="btn btn-outline-primary disabled"


### PR DESCRIPTION
## Root cause

Archived posts (front-matter flag `archive: true`) are correctly hidden from the Archives listing (`_layouts/archives.html` filters `post.archive != true`), but they leaked back in via the Previous/Next buttons at the bottom of adjacent posts. `_includes/post-nav.html` used Jekyll's built-in `page.previous` / `page.next`, which traverse the entire chronological post sequence and ignore the `archive` flag. See issue #4.

## Fix

`_includes/post-nav.html` now walks `site.posts` to precompute the nearest NON-archived neighbor in each direction — skipping archived posts and the current page — then renders the same two buttons, collapsing to the disabled `-` state at a sequence boundary just as before. Single-file change; no theme or copy edits.

## Verification

Built with `JEKYLL_ENV=production bundle exec jekyll b` and inspected the generated HTML under `_site/`. The archived post `Welcome to jrj.org` (`/2025/12/08/Welcome/`, `archive: true`) sits between two non-archived posts. Observed:

- **Prev/older skips archived:** PowerBook post's Previous button → `Retired from Disney, after 30+ years in the industry` (`/2025/12/08/Retired-from-Disney-and-30-plus-years/`), not Welcome.
- **Next/newer skips archived:** Retired-from-Disney post's Next button → `PowerBook 170: My First Laptop... sort of` (`/2025/12/09/PowerBook-170-Retro-Mac/`), not Welcome.
- **Boundary:** newest post (`The Promises I was Quietly Breaking`, 2026-07-14) shows the disabled `-` span for Next — no dangling link.
- **Global:** grepped every `post-navigation` block in `_site` — the archived Welcome URL (`/2025/12/08/Welcome/`) appears in **zero** posts' prev/next navigation. Interior posts still show sensible Previous+Next links (e.g. the App Store post links PowerBook ↔ Promises).

Closes #4